### PR TITLE
set string to be between 50 and 1

### DIFF
--- a/preordain/search/models.py
+++ b/preordain/search/models.py
@@ -1,0 +1,17 @@
+#
+# todo: validate the /search/{query} with this.
+# from pydantic import validator, BaseModel
+
+# class SearchQuery(str):
+#     search: str
+
+#     # def __init__(self, string_literal):
+#     #     search = string_literal
+
+#     @validator('search', pre=True)
+#     def sanititize_str(cls, v:str):
+#         if len(v) >= 50:
+#             raise Exception("Hey maybe don't so much")
+#         if len(v) <= 0:
+#             raise Exception("Maybe like, search for a card")
+#         return v

--- a/preordain/search/router.py
+++ b/preordain/search/router.py
@@ -5,13 +5,18 @@ from preordain.utils.connections import connect_db
 from fastapi import APIRouter, Response, status
 from preordain.information.utils import parse_data_for_response
 from preordain.information.models import CardInformation
+# from preordain.search.models import SearchQuery
 from preordain.models import BaseResponse
 
 search_router = APIRouter()
 
-
 @search_router.get("/{query}")
 async def search_for_card(query: str, response: Response):
+    if len(query) >= 50:
+        raise Exception("Hey maybe don't so much")
+    if len(query) <= 0:
+        raise Exception("Maybe like, search for a card")
+
     conn, cur = connect_db()
     cur.execute(
         """

--- a/tests/search/test_search_response.py
+++ b/tests/search/test_search_response.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-
+import pytest
 
 def test_search_single(client: TestClient):
     data = {
@@ -26,3 +26,14 @@ def test_search_single(client: TestClient):
     response = client.get("/search/thalia")
     assert response.status_code == 200
     assert response.json() == data
+
+def test_over_50_char(client: TestClient):
+    search_query = 'A' * 51
+    print(type(search_query))
+    with pytest.raises(Exception):
+        client.get(f"/search/{search_query}")
+
+
+# def test_under_50_char(client: TestClient):
+#     search_query = ''
+#     response = client.get("/search/thalia")


### PR DESCRIPTION
Temporary solution, having `{query}` be a Subclass isn't the way as it throws an AssertionError, saying the path isn't valid.

Otherwise, should be fine running things. 